### PR TITLE
fixup: Recsum.1sc refactor

### DIFF
--- a/Recsum.1sc
+++ b/Recsum.1sc
@@ -23,7 +23,7 @@ int USERDATA_10_SIZE = 0x60000;
 int MAX_CHARACTER_COUNT = 10;
 
 // Recalculate checksum for active character slots
-for(byte i = 0; i < MAX_CHARACTER_COUNT; i++) {
+for(i = 0; i < MAX_CHARACTER_COUNT; i++) {
     if((ReadByte(active_slots_offset + i)) != 1)
     {
         continue;   

--- a/Recsum.1sc
+++ b/Recsum.1sc
@@ -9,7 +9,6 @@
 //   History: 
 //------------------------------------------------
 
-int i = 0;
 uint64 offset;
 int active_slots_offset = 0x1901D04;
 uchar buffer[0x280000];
@@ -23,7 +22,7 @@ int USERDATA_10_SIZE = 0x60000;
 int MAX_CHARACTER_COUNT = 10;
 
 // Recalculate checksum for active character slots
-for(i = 0; i < MAX_CHARACTER_COUNT; i++) {
+for(int i = 0; i < MAX_CHARACTER_COUNT; i++) {
     // Check that slot is active. If not, skip.
     if((ReadByte(active_slots_offset + i)) != 1) continue;
     // Calculate the offset to the start of a character, skipping checksum bytes.

--- a/Recsum.1sc
+++ b/Recsum.1sc
@@ -11,7 +11,6 @@
 
 int i = 0;
 uint64 offset;
-int slots_count = 0;
 int active_slots_offset = 0x1901D04;
 uchar buffer[0x280000];
 uchar result[0x10];
@@ -23,15 +22,12 @@ int CHECKSUM_SIZE = 0x10;
 int USERDATA_10_SIZE = 0x60000;
 int MAX_CHARACTER_COUNT = 10;
 
-// Count active slots
-while(i < 10) {
-    if((ReadByte(active_slots_offset + 0x1*i)) == 1) slots_count++;
-    i++;
-}
-
 // Recalculate checksum for active character slots
-i = 0;
-while(i < slots_count) {
+for(byte i = 0; i < MAX_CHARACTER_COUNT; i++) {
+    if((ReadByte(active_slots_offset + i)) != 1)
+    {
+        continue;   
+    }
     // Calculate the offset to the start of a character, skipping checksum bytes.
     offset = HEADER_SIZE + ((CHARACTER_FILE_SIZE + CHECKSUM_SIZE) * i); 
     // Move the cursor position to offset
@@ -42,12 +38,10 @@ while(i < slots_count) {
     ChecksumAlgArrayBytes( CHECKSUM_MD5, result, buffer, CHARACTER_FILE_SIZE);
     // Overwrite old checksum with the new checksum.
     WriteBytes(result, offset, CHECKSUM_SIZE);
-    // Increment index
-    i++;
 }
 
 // Recalculate checksum for USER_DATA_10
-offset = HEADER_SIZE + (CHARACTER_FILE_SIZE * MAX_CHARACTER_COUNT);
+offset = HEADER_SIZE + ((CHARACTER_FILE_SIZE + CHECKSUM_SIZE) * MAX_CHARACTER_COUNT);
 SetCursorPos( offset );
 ReadBytes(buffer, offset + CHECKSUM_SIZE, USERDATA_10_SIZE);
 ChecksumAlgArrayBytes( CHECKSUM_MD5, result, buffer, USERDATA_10_SIZE);

--- a/Recsum.1sc
+++ b/Recsum.1sc
@@ -24,10 +24,8 @@ int MAX_CHARACTER_COUNT = 10;
 
 // Recalculate checksum for active character slots
 for(i = 0; i < MAX_CHARACTER_COUNT; i++) {
-    if((ReadByte(active_slots_offset + i)) != 1)
-    {
-        continue;   
-    }
+    // Check that slot is active. If not, skip.
+    if((ReadByte(active_slots_offset + i)) != 1) continue;
     // Calculate the offset to the start of a character, skipping checksum bytes.
     offset = HEADER_SIZE + ((CHARACTER_FILE_SIZE + CHECKSUM_SIZE) * i); 
     // Move the cursor position to offset


### PR DESCRIPTION
Recsum.1sc has 2 issues:
1. It calculates the _number_ of slots to update the checksum of, instead of actually detecting _which_ slots are active. If the slots were guaranteed to be sequential then this would be fine, but since all that deleting a slot in-game does is mark its slot as Inactive, the script needs to account for the possibility that the slots are not sequential.
2. There's a logic error in calculating the offset for `USER_DATA10`. In the loop for calculating the character slots, the offset is correctly set to `HEADER_SIZE + ((CHARACTER_FILE_SIZE + CHECKSUM_SIZE) * i)`, but in the logic for `USER_DATA10` it misses the `CHECKSUM_SIZE`. This shifts the checksum by `CHECKSUM_SIZE * MAX_CHARACTER_COUNT` bytes, writing it into the end of `Character[9]` instead, corrupting that slot due to a mismatched checksum. Running the script again _kinda_ fixes this if all slots are filled, since the checksum for `USER_DATA10` won't change, although if any slot is marked as inactive then 1 will cause this to fail too.

The fix for 1 is to move the logic for detecting active slots INTO the loop for recalculating the checksums. I also rewrote it into a for loop since it's slightly cleaner.
The fix for 2 is to add the `CHECKSUM_SIZE` to the `CHARACTER_FILE_SIZE` while calculating the offset.